### PR TITLE
Move theme toggle to bottom-right

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,7 +174,7 @@
 
     .theme-toggle {
       position: fixed;
-      left: clamp(1rem, 4vw, 2rem);
+      right: clamp(1rem, 4vw, 2rem);
       bottom: clamp(1rem, 4vw, 2rem);
       width: 2.25rem;
       height: 2.25rem;


### PR DESCRIPTION
Moves the light/dark toggle from bottom-left to bottom-right so it doesn't overlap the left-aligned content (name, statement, CTA) on mobile. One-line CSS change (`left:` → `right:` on `.theme-toggle`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)